### PR TITLE
Comment out hg, make, sqlite in swc-installation-test-2.py

### DIFF
--- a/setup/swc-installation-test-2.py
+++ b/setup/swc-installation-test-2.py
@@ -90,11 +90,11 @@ CHECKS = [
     'virtual-browser',
 # Version control
     'git',
-    'hg',              # Command line tool
+    #'hg',              # Command line tool
     #'mercurial',       # Python package
-    'EasyMercurial',
+    #'EasyMercurial',
 # Build tools and packaging
-    'make',
+    #'make',
     'virtual-pypi-installer',
     'setuptools',
     #'xcode',
@@ -104,8 +104,8 @@ CHECKS = [
     'py.test',         # Command line tool
     'pytest',          # Python package
 # SQL
-    'sqlite3',         # Command line tool
-    'sqlite3-python',  # Python package
+    #'sqlite3',         # Command line tool
+    #'sqlite3-python',  # Python package
 # Python
     'python',
     'ipython',         # Command line tool


### PR DESCRIPTION
- Since we're not using make, mercurial and sqlite, we should comment
  these out from the installation tests
